### PR TITLE
Rename all the MainDivs (Modified them to CamelCase) #37

### DIFF
--- a/frontend/src/components/Controls.vue
+++ b/frontend/src/components/Controls.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="divControls">
+    <div id="ControlsMainDiv">
         <ion-button @mousedown="left" @mouseup="stopMoving" @touchstart="left" @touchend="stopMoving">Left</ion-button>
         <ion-button @mousedown="right" @mouseup="stopMoving" @touchstart="right" @touchend="stopMoving">Right</ion-button>
         <ion-button @mousedown="up" @mouseup="stopMoving" @touchstart="up" @touchend="stopMoving">Up</ion-button>
@@ -17,7 +17,7 @@ const { left, right, up, down, stopMoving, movement } = useMovement();
 </script>
 
 <style scoped>
-#divControls {
+#ControlsMainDiv {
     display: flex;
     justify-content: space-between;
 }

--- a/frontend/src/components/Controls.vue
+++ b/frontend/src/components/Controls.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="ControlsMainDiv">
+    <div id="controlsMainDiv">
         <ion-button @mousedown="left" @mouseup="stopMoving" @touchstart="left" @touchend="stopMoving">Left</ion-button>
         <ion-button @mousedown="right" @mouseup="stopMoving" @touchstart="right" @touchend="stopMoving">Right</ion-button>
         <ion-button @mousedown="up" @mouseup="stopMoving" @touchstart="up" @touchend="stopMoving">Up</ion-button>
@@ -17,7 +17,7 @@ const { left, right, up, down, stopMoving, movement } = useMovement();
 </script>
 
 <style scoped>
-#ControlsMainDiv {
+#controlsMainDiv {
     display: flex;
     justify-content: space-between;
 }

--- a/frontend/src/components/MainCanvas.vue
+++ b/frontend/src/components/MainCanvas.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="MainCanvasMainDiv">
+    <div id="mainCanvasMainDiv">
         <div id="divCanvas">
             <canvas id="mainCanvas"></canvas>
         </div>
@@ -313,7 +313,7 @@ function levelDown() {
 </script>
 
 <style scoped>
-#MainCanvasMainDiv {
+#mainCanvasMainDiv {
     display: grid;
 }
 

--- a/frontend/src/components/MainCanvas.vue
+++ b/frontend/src/components/MainCanvas.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="divMain">
+    <div id="MainCanvasMainDiv">
         <div id="divCanvas">
             <canvas id="mainCanvas"></canvas>
         </div>
@@ -313,7 +313,7 @@ function levelDown() {
 </script>
 
 <style scoped>
-#divMain {
+#MainCanvasMainDiv {
     display: grid;
 }
 

--- a/frontend/src/components/MainWord.vue
+++ b/frontend/src/components/MainWord.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="divMainMainWord">
+    <div id="mainWordMainDiv">
         <ion-label>
             <h1>{{ mainStore.wordRelated.currentWordToLearn }}</h1>
         </ion-label>
@@ -38,7 +38,7 @@ const mainStore = useMainStore();
 </script>
 
 <style scoped>
-#divMainMainWord {
+#mainWordMainDiv {
     display: grid;
 }
 </style>

--- a/frontend/src/components/ScoreAndLevel.vue
+++ b/frontend/src/components/ScoreAndLevel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="ScoreAndLevelMainDiv">
+    <div id="scoreAndLevelMainDiv">
         <ion-label>
             <h1>Score: {{ mainStore.score }}</h1>
         </ion-label>
@@ -19,7 +19,7 @@ const mainStore = useMainStore();
 </script>
 
 <style scoped>
-#ScoreAndLevelMainDiv {
+#scoreAndLevelMainDiv {
     display: flex;
 }
 

--- a/frontend/src/components/ScoreAndLevel.vue
+++ b/frontend/src/components/ScoreAndLevel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="divMain">
+    <div id="ScoreAndLevelMainDiv">
         <ion-label>
             <h1>Score: {{ mainStore.score }}</h1>
         </ion-label>
@@ -19,7 +19,7 @@ const mainStore = useMainStore();
 </script>
 
 <style scoped>
-#divMain {
+#ScoreAndLevelMainDiv {
     display: flex;
 }
 

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="divMainSettings">
+    <div id="SettingsMainDiv">
         <div id="divTopSettings">
             <ion-item
                 class="ion-text-center custom-background"
@@ -51,7 +51,7 @@ function saveWord(event){
 <style scoped>
 
 
-#divMainSettings {
+#SettingsMainDiv {
     display: grid;
 }
 

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="SettingsMainDiv">
+    <div id="settingsMainDiv">
         <div id="divTopSettings">
             <ion-item
                 class="ion-text-center custom-background"
@@ -51,7 +51,7 @@ function saveWord(event){
 <style scoped>
 
 
-#SettingsMainDiv {
+#settingsMainDiv {
     display: grid;
 }
 

--- a/frontend/src/components/SpeedController.vue
+++ b/frontend/src/components/SpeedController.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="divMain">
+    <div id="SpeedControllerMainDiv">
         <ion-range @ionChange="ChangeSpeed($event)" :pin="true" :ticks="true" :snaps="true" :min="1" :max="8"
             label="Speed! "></ion-range>
     </div>
@@ -18,7 +18,7 @@ function ChangeSpeed($event){
 </script>
 
 <style>
-#divMain {
+#SpeedControllerMainDiv {
     display: grid;
 }
 

--- a/frontend/src/components/SpeedController.vue
+++ b/frontend/src/components/SpeedController.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="SpeedControllerMainDiv">
+    <div id="speedControllerMainDiv">
         <ion-range @ionChange="ChangeSpeed($event)" :pin="true" :ticks="true" :snaps="true" :min="1" :max="8"
             label="Speed! "></ion-range>
     </div>
@@ -18,7 +18,7 @@ function ChangeSpeed($event){
 </script>
 
 <style>
-#SpeedControllerMainDiv {
+#speedControllerMainDiv {
     display: grid;
 }
 


### PR DESCRIPTION
This pull request addresses issue #37 by renaming all components main <div> elements with generic class names like "Controls" to "ControlsMainDiv" as you have mentioned. This improves code readability and helps future contributors understand the layout better. I made the changes in 6 files of components (Controls.vue, MainCanvas.vue, MainWord.vue, ScoreAndLevel.vue, Settings.vue, SpeedController.vue)

Let me know if any changes or refinements are needed 😊